### PR TITLE
Reverse the frame construction for easier decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ The following SigFox frame 25472d427f6ac43fdc000000 is
 </pre>
 
 
+##Decode the data on the Sigfox cloud
+
+Edit your [Device Type](https://backend.sigfox.com/devicetype/:id/edit), and set the _Display Type_ to `Custom`
+
+Then set the custom configuration to 
+
+```
+alt::uint:32 lng::float:32 lat::float:32
+```
+
+The Sigfox cloud will automatically parse the received frames & display the associated alt, lat & lng.
+
 ## What can I find in this repository ?
 - __sigfox_gps__ : the Arduino sketch + TinyGPS library.
 - __decode.php__ : example code to show how to decode sigfox data sent by the Arduino sketch.

--- a/sigfox_gps/sigfox_gps.ino
+++ b/sigfox_gps/sigfox_gps.ino
@@ -65,7 +65,7 @@ int   altitude  = 0;
 
 // Set to 1 to get debug messages to console
 // If you set if to 1, you'll have to connect to the serial console to allow the program to run
-#define DEBUG 0
+#define DEBUG 1
 
 void setup() {
 
@@ -200,7 +200,8 @@ bool sigfoxSend(const void* data, uint8_t len) {
   SigFox.print('S');
   SigFox.print('F');
   SigFox.print('=');
-  for(uint8_t i = 0; i < len; ++i) {
+  //0-1 == 255 --> (0-1) > len
+  for(uint8_t i = len-1; i < len; --i) {
     if (bytes[i] < 16) {SigFox.print("0");}
     SigFox.print(bytes[i], HEX);
   }
@@ -213,7 +214,7 @@ bool sigfoxSend(const void* data, uint8_t len) {
     SerialUSB.print('S');
     SerialUSB.print('F');
     SerialUSB.print('=');
-    for(uint8_t i = 0; i < len; ++i) {
+    for(uint8_t i = len-1; i < len; --i) {
       if (bytes[i] < 16) {SerialUSB.print("0");}
       SerialUSB.print(bytes[i], HEX);
     }

--- a/sigfox_gps/sigfox_gps.ino
+++ b/sigfox_gps/sigfox_gps.ino
@@ -65,7 +65,7 @@ int   altitude  = 0;
 
 // Set to 1 to get debug messages to console
 // If you set if to 1, you'll have to connect to the serial console to allow the program to run
-#define DEBUG 1
+#define DEBUG 0
 
 void setup() {
 


### PR DESCRIPTION
Parsing the struct bytes in reverse order will help decoding easily the received data 
- Instructions about how to decode using the Sigfox backend
